### PR TITLE
upgrade to requiring explicit Infinity needs

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@
                 return lock = arguments[0];
               };
             })(),
-            lineno: 28
+            lineno: 26
           }), true);
           __iced_deferrals._fulfill();
         });
@@ -69,7 +69,7 @@
                       funcname: "ACache.query"
                     });
                     process.nextTick(__iced_deferrals.defer({
-                      lineno: 31
+                      lineno: 29
                     }));
                     __iced_deferrals._fulfill();
                   })(__iced_k);
@@ -91,7 +91,7 @@
                       return res_array = __slice.call(arguments, 1);
                     };
                   })(),
-                  lineno: 33
+                  lineno: 31
                 }));
                 __iced_deferrals._fulfill();
               })(function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acache",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A simple JavaScript locking/caching of async queries/call results",
   "main": "index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   "dependencies": {
     "iced-runtime": "^1.0.3",
     "iced-utils": "^0.1.24",
-    "kb-node-lru": "^1.0.0",
-    "object-hash": "^1.1.4"
+    "kb-node-lru": "^2.0.0",
+    "object-hash": "^1.1.7"
   }
 }

--- a/test/files/2_mandatory_params.iced
+++ b/test/files/2_mandatory_params.iced
@@ -1,0 +1,51 @@
+{ACache}  = require '../../index.js'
+
+# -------------------------------------------------------------------------
+# Starting in v2.0.0, constructor insists on both max_age_ms and max_storage
+#  to prevent user error of passing one of them with a typo and inferring
+#  Infinity. (Infinity must be explicitly requested now.)
+# -------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
+
+exports.missing_options = (T, cb) ->
+  try
+    c = new ACache()
+    caught = false
+  catch e
+    caught = true
+  T.assert caught, "recognized missing options"
+  cb()
+
+# -------------------------------------------------------------------------
+
+exports.missing_max_age_ms = (T, cb) ->
+  try
+    # note it's supposed to be max_age_ms, not max_age
+    c = new ACache {max_age: 1000, max_storage: 3}
+    caught = false
+  catch e
+    caught = true
+  T.assert caught, "recognized missing options"
+  cb()
+
+# -------------------------------------------------------------------------
+
+exports.missing_max_storage = (T, cb) ->
+  try
+    # note it's supposed to be max_storage, not max_store
+    c = new ACache {max_age_ms: 1000, max_store: 3}
+    caught = false
+  catch e
+    caught = true
+  T.assert caught, "recognized missing options"
+  cb()
+
+# -------------------------------------------------------------------------
+
+exports.infinities_ok = (T, cb) ->
+  c = new ACache {max_age_ms: Infinity, max_storage: Infinity}
+  T.assert c
+  cb()
+
+# -------------------------------------------------------------------------


### PR DESCRIPTION
@maxtaco - I updated my core `lru` and `acache` libraries not to infer `Infinity` when called without `max_age_ms` or `max_storage`. I once found an error when I had called it `max_age` instead of `max_age_ms`, and that shouldn't be possible.

I'm going to approve this myself. It's unlikely to be our memory problem on keybase, but it's nagged me every time I've thought about memory leakage. 